### PR TITLE
Add Rust unit tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Run tests
+        run: cargo test --verbose

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,3 +128,36 @@ fn smith_waterman_internal(seq1: &str, seq2: &str) -> AlignmentResult {
     }
 }
 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn align_identical_sequences() {
+        let r = smith_waterman_internal("GATTACA", "GATTACA");
+        assert_eq!(r.aligned_seq1, "GATTACA");
+        assert_eq!(r.aligned_seq2, "GATTACA");
+        assert_eq!(r.aligned_length, 7);
+        assert!((r.aligned_identity - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn align_acacacta_agcacaca() {
+        let r = smith_waterman_internal("ACACACTA", "AGCACACA");
+        assert_eq!(r.aligned_seq1, "A-CACACTA");
+        assert_eq!(r.aligned_seq2, "AGCACAC-A");
+        assert_eq!(r.aligned_length, 7);
+        assert!((r.aligned_identity - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn align_gattaca_gcatgcu() {
+        let r = smith_waterman_internal("GATTACA", "GCATGCU");
+        assert_eq!(r.aligned_seq1, "G-AT---TACA");
+        assert_eq!(r.aligned_seq2, "GCATGCU----");
+        assert_eq!(r.aligned_length, 3);
+        assert!((r.aligned_identity - 1.0).abs() < f64::EPSILON);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a workflow to run `cargo test`
- create unit tests for the Smith–Waterman implementation

## Testing
- `cargo test -- --nocapture`
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_686a2a6182a08333a06997c040d32cbc