### PR TITLE
Enhance alignment output

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8">
     <title>Sequence Alignment</title>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <style>
+        #result-container pre {
+            font-family: monospace;
+        }
+        .match { color: green; }
+        .mismatch { color: red; }
+        .gap { color: gray; }
+    </style>
 </head>
 <body>
 
@@ -33,13 +41,32 @@
                 const parsed2 = parseFasta(document.getElementById('seq2').value, 'sequence2');
                 const result = smith_waterman(parsed1.sequence, parsed2.sequence);
                 document.getElementById('result-container').style.visibility = 'visible';
-                document.getElementById('result').textContent =
-                    '>' + parsed1.name + '\n' +
-                    result.aligned_seq1 + '\n' +
-                    '>' + parsed2.name + '\n' +
-                    result.aligned_seq2;
+
+                const seq1 = result.aligned_seq1;
+                const seq2 = result.aligned_seq2;
+                let html1 = '';
+                let html2 = '';
+                for (let i = 0; i < seq1.length; i++) {
+                    const c1 = seq1[i];
+                    const c2 = seq2[i];
+                    let cls = 'match';
+                    if (c1 === '-' || c2 === '-') {
+                        cls = 'gap';
+                    } else if (c1 !== c2) {
+                        cls = 'mismatch';
+                    }
+                    html1 += `<span class="${cls}">${c1}</span>`;
+                    html2 += `<span class="${cls}">${c2}</span>`;
+                }
+
+                document.getElementById('result').innerHTML =
+                    '&gt;' + parsed1.name + '\n' +
+                    html1 + '\n' +
+                    '&gt;' + parsed2.name + '\n' +
+                    html2;
+
                 document.getElementById('alignment-length').textContent = result.aligned_length;
-                document.getElementById('alignment-score').textContent = (100*result.aligned_identity).toFixed(2) + '%';
+                document.getElementById('alignment-score').textContent = (100 * result.aligned_identity).toFixed(2) + '%';
             };
 
         }


### PR DESCRIPTION
## Summary
- improve the color-coded alignment visualization in `index.html`
- add simple styles for matches, mismatches and gaps

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686b7c967f5883339c7b7421d2022578