### PR TITLE
Enable custom alignment parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 <body>
 
     <script type="module">
-        import init, { smith_waterman } from './pkg/web_bio_tools.js';
+        import init, { smith_waterman_with_params } from './pkg/web_bio_tools.js';
 
         async function run() {
             await init();
@@ -31,7 +31,10 @@
             window.alignSequences = () => {
                 const parsed1 = parseFasta(document.getElementById('seq1').value, 'sequence1');
                 const parsed2 = parseFasta(document.getElementById('seq2').value, 'sequence2');
-                const result = smith_waterman(parsed1.sequence, parsed2.sequence);
+                const matchScore = parseInt(document.getElementById('match-score').value, 10);
+                const mismatchPenalty = parseInt(document.getElementById('mismatch-penalty').value, 10);
+                const gapPenalty = parseInt(document.getElementById('gap-penalty').value, 10);
+                const result = smith_waterman_with_params(parsed1.sequence, parsed2.sequence, matchScore, mismatchPenalty, gapPenalty);
                 document.getElementById('result-container').style.visibility = 'visible';
                 document.getElementById('result').textContent =
                     '>' + parsed1.name + '\n' +
@@ -59,6 +62,11 @@
     <textarea id="seq1" placeholder="Enter first sequence (FASTA or raw)"></textarea>
     <textarea id="seq2" placeholder="Enter second sequence (FASTA or raw)"></textarea>
     <p><a href="#" id="load-example">Load example sequences</a></p>
+    <p>
+        <label>Match score: <input type="number" id="match-score" value="2"></label>
+        <label>Mismatch penalty: <input type="number" id="mismatch-penalty" value="-1"></label>
+        <label>Gap penalty: <input type="number" id="gap-penalty" value="-1"></label>
+    </p>
     <button onclick="alignSequences()">Align</button>
     <div id="result-container"
          style="visibility: hidden;">

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -9,14 +9,20 @@ pub struct AlignmentResult {
 }
 
 pub fn smith_waterman_internal(seq1: &str, seq2: &str) -> AlignmentResult {
+    smith_waterman_internal_with_params(seq1, seq2, 2, -1, -1)
+}
+
+pub fn smith_waterman_internal_with_params(
+    seq1: &str,
+    seq2: &str,
+    match_score: i32,
+    mismatch_penalty: i32,
+    gap_penalty: i32,
+) -> AlignmentResult {
     let seq1 = seq1.as_bytes();
     let seq2 = seq2.as_bytes();
     let len1 = seq1.len();
     let len2 = seq2.len();
-
-    let match_score = 2;
-    let mismatch_penalty = -1;
-    let gap_penalty = -1;
 
     // Initialize scoring matrix
     let mut score_matrix = vec![vec![0; len2 + 1]; len1 + 1];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,23 @@ pub use alignment::AlignmentResult;
 
 #[wasm_bindgen]
 pub fn smith_waterman(seq1: &str, seq2: &str) -> JsValue {
-    let result = alignment::smith_waterman_internal(seq1, seq2);
+    smith_waterman_with_params(seq1, seq2, 2, -1, -1)
+}
+
+#[wasm_bindgen]
+pub fn smith_waterman_with_params(
+    seq1: &str,
+    seq2: &str,
+    match_score: i32,
+    mismatch_penalty: i32,
+    gap_penalty: i32,
+) -> JsValue {
+    let result = alignment::smith_waterman_internal_with_params(
+        seq1,
+        seq2,
+        match_score,
+        mismatch_penalty,
+        gap_penalty,
+    );
     to_value(&result).unwrap()
 }


### PR DESCRIPTION
## Summary
- allow passing scoring parameters to the Rust alignment routine
- expose new `smith_waterman_with_params` function to JS
- add HTML inputs for match, mismatch and gap costs
- plumb parameter values into the alignment call

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686b7ccd866083338561b691b5e93245