### PR TITLE
Add Needleman-Wunsch algorithm option

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     </style>
 
     <script type="module">
-        import init, { smith_waterman_custom, smith_waterman_blosum62 } from './pkg/web_bio_tools.js';
+        import init, { smith_waterman_custom, smith_waterman_blosum62, needleman_wunsch_custom, needleman_wunsch_blosum62 } from './pkg/web_bio_tools.js';
 
         async function run() {
             await init();
@@ -45,13 +45,24 @@
                 const parsed2 = parseFasta(document.getElementById('seq2').value, 'sequence2');
                 const gapPenalty = parseInt(document.getElementById('gap-penalty').value, 10);
                 const weightOption = document.getElementById('weight-option').value;
+                const algorithm = document.getElementById('algorithm').value;
                 let result;
-                if (weightOption === 'blosum62') {
-                    result = smith_waterman_blosum62(parsed1.sequence, parsed2.sequence, gapPenalty);
+                if (algorithm === 'nw') {
+                    if (weightOption === 'blosum62') {
+                        result = needleman_wunsch_blosum62(parsed1.sequence, parsed2.sequence, gapPenalty);
+                    } else {
+                        const matchScore = parseInt(document.getElementById('match-score').value, 10);
+                        const mismatchPenalty = parseInt(document.getElementById('mismatch-penalty').value, 10);
+                        result = needleman_wunsch_custom(parsed1.sequence, parsed2.sequence, matchScore, mismatchPenalty, gapPenalty);
+                    }
                 } else {
-                    const matchScore = parseInt(document.getElementById('match-score').value, 10);
-                    const mismatchPenalty = parseInt(document.getElementById('mismatch-penalty').value, 10);
-                    result = smith_waterman_custom(parsed1.sequence, parsed2.sequence, matchScore, mismatchPenalty, gapPenalty);
+                    if (weightOption === 'blosum62') {
+                        result = smith_waterman_blosum62(parsed1.sequence, parsed2.sequence, gapPenalty);
+                    } else {
+                        const matchScore = parseInt(document.getElementById('match-score').value, 10);
+                        const mismatchPenalty = parseInt(document.getElementById('mismatch-penalty').value, 10);
+                        result = smith_waterman_custom(parsed1.sequence, parsed2.sequence, matchScore, mismatchPenalty, gapPenalty);
+                    }
                 }
                 document.getElementById('result-container').style.visibility = 'visible';
 
@@ -143,12 +154,18 @@
             </div>
             <div class="col">
                 <h1>Web Bio Tools</h1>
-                <h2>Sequence Alignment using Smith-Waterman</h2>
+                <h2>Sequence Alignment</h2>
                 <textarea id="seq1" placeholder="Enter first sequence (FASTA or raw)" rows=24 cols=48></textarea>
                 <textarea id="seq2" placeholder="Enter second sequence (FASTA or raw)" rows=24 cols=48></textarea>
                 <p><a href="#" id="load-example">Load example sequences</a></p>
                 <p><a href="#" id="toggle-advanced">Show advanced parameters</a></p>
                 <div id="advanced-params" style="display:none;">
+                    <label>Algorithm:
+                        <select id="algorithm">
+                            <option value="sw" selected>Smith-Waterman (local)</option>
+                            <option value="nw">Needleman-Wunsch (global)</option>
+                        </select>
+                    </label><br>
                     <label>Scoring matrix:
                         <select id="weight-option">
                             <option value="uniform" selected>Uniform</option>
@@ -169,8 +186,8 @@
 
                 <p>
                     This site provides simple bioinformatics tools compiled to WebAssembly
-                    with Rust. The current tool performs Smith-Waterman local sequence
-                    alignment directly in your browser.
+                    with Rust. It can perform local or global sequence alignment
+                    directly in your browser.
                 </p>
                 <p>
                     Source code available on <a href="https://github.com/luispedro/web-bio-tools">GitHub</a>.<br>

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -191,6 +191,106 @@ pub fn smith_waterman_internal(
     })
 }
 
+pub fn needleman_wunsch_with_matrix<F>(
+    seq1: &str,
+    seq2: &str,
+    gap_penalty: i32,
+    score_fn: F,
+) -> AlignmentResult
+where
+    F: Fn(u8, u8) -> i32,
+{
+    let seq1 = seq1.as_bytes();
+    let seq2 = seq2.as_bytes();
+    let len1 = seq1.len();
+    let len2 = seq2.len();
+
+    let mut score_matrix = vec![vec![0; len2 + 1]; len1 + 1];
+
+    for i in 1..=len1 {
+        score_matrix[i][0] = score_matrix[i - 1][0] + gap_penalty;
+    }
+    for j in 1..=len2 {
+        score_matrix[0][j] = score_matrix[0][j - 1] + gap_penalty;
+    }
+
+    for i in 1..=len1 {
+        for j in 1..=len2 {
+            let match_mismatch = score_fn(seq1[i - 1], seq2[j - 1]);
+            let diagonal_score = score_matrix[i - 1][j - 1] + match_mismatch;
+            let up_score = score_matrix[i - 1][j] + gap_penalty;
+            let left_score = score_matrix[i][j - 1] + gap_penalty;
+            score_matrix[i][j] = diagonal_score.max(up_score).max(left_score);
+        }
+    }
+
+    let mut i = len1;
+    let mut j = len2;
+    let mut aligned_seq1 = Vec::new();
+    let mut aligned_seq2 = Vec::new();
+    let mut aligned_length = 0;
+    let mut aligned_identity = 0.0;
+
+    while i > 0 || j > 0 {
+        if i > 0
+            && j > 0
+            && score_matrix[i][j]
+                == score_matrix[i - 1][j - 1] + score_fn(seq1[i - 1], seq2[j - 1])
+        {
+            aligned_seq1.push(seq1[i - 1]);
+            aligned_seq2.push(seq2[j - 1]);
+            if seq1[i - 1] == seq2[j - 1] {
+                aligned_identity += 1.0;
+            }
+            aligned_length += 1;
+            i -= 1;
+            j -= 1;
+        } else if i > 0 && score_matrix[i][j] == score_matrix[i - 1][j] + gap_penalty {
+            aligned_seq1.push(seq1[i - 1]);
+            aligned_seq2.push(b'-');
+            i -= 1;
+        } else {
+            aligned_seq1.push(b'-');
+            aligned_seq2.push(seq2[j - 1]);
+            j -= 1;
+        }
+    }
+
+    aligned_seq1.reverse();
+    aligned_seq2.reverse();
+
+    AlignmentResult {
+        aligned_seq1: String::from_utf8(aligned_seq1).unwrap(),
+        aligned_seq2: String::from_utf8(aligned_seq2).unwrap(),
+        aligned_length,
+        aligned_identity: if aligned_length > 0 {
+            aligned_identity / aligned_length as f64
+        } else {
+            0.0
+        },
+    }
+}
+
+pub fn needleman_wunsch_blosum62_internal(
+    seq1: &str,
+    seq2: &str,
+    gap_penalty: i32,
+) -> AlignmentResult {
+    needleman_wunsch_with_matrix(seq1, seq2, gap_penalty, blosum62_score)
+}
+
+pub fn needleman_wunsch_internal(
+    seq1: &str,
+    seq2: &str,
+    match_score: i32,
+    mismatch_penalty: i32,
+    gap_penalty: i32,
+) -> AlignmentResult {
+    needleman_wunsch_with_matrix(seq1, seq2, gap_penalty, |a, b| {
+        if a == b { match_score } else { mismatch_penalty }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -225,6 +325,24 @@ mod tests {
     #[test]
     fn blosum62_identical_sequences() {
         let r = smith_waterman_blosum62_internal("GATTACA", "GATTACA", -1);
+        assert_eq!(r.aligned_seq1, "GATTACA");
+        assert_eq!(r.aligned_seq2, "GATTACA");
+        assert_eq!(r.aligned_length, 7);
+        assert!((r.aligned_identity - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn nw_identical_sequences() {
+        let r = needleman_wunsch_internal("GATTACA", "GATTACA", 2, -1, -1);
+        assert_eq!(r.aligned_seq1, "GATTACA");
+        assert_eq!(r.aligned_seq2, "GATTACA");
+        assert_eq!(r.aligned_length, 7);
+        assert!((r.aligned_identity - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn nw_blosum62_identical_sequences() {
+        let r = needleman_wunsch_blosum62_internal("GATTACA", "GATTACA", -1);
         assert_eq!(r.aligned_seq1, "GATTACA");
         assert_eq!(r.aligned_seq2, "GATTACA");
         assert_eq!(r.aligned_length, 7);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,3 +34,32 @@ pub fn smith_waterman_blosum62(seq1: &str, seq2: &str, gap_penalty: i32) -> JsVa
     let result = alignment::smith_waterman_blosum62_internal(seq1, seq2, gap_penalty);
     to_value(&result).unwrap()
 }
+
+#[wasm_bindgen]
+pub fn needleman_wunsch(seq1: &str, seq2: &str) -> JsValue {
+    needleman_wunsch_custom(seq1, seq2, 2, -1, -1)
+}
+
+#[wasm_bindgen]
+pub fn needleman_wunsch_custom(
+    seq1: &str,
+    seq2: &str,
+    match_score: i32,
+    mismatch_penalty: i32,
+    gap_penalty: i32,
+) -> JsValue {
+    let result = alignment::needleman_wunsch_internal(
+        seq1,
+        seq2,
+        match_score,
+        mismatch_penalty,
+        gap_penalty,
+    );
+    to_value(&result).unwrap()
+}
+
+#[wasm_bindgen]
+pub fn needleman_wunsch_blosum62(seq1: &str, seq2: &str, gap_penalty: i32) -> JsValue {
+    let result = alignment::needleman_wunsch_blosum62_internal(seq1, seq2, gap_penalty);
+    to_value(&result).unwrap()
+}


### PR DESCRIPTION
## Summary
- implement Needleman-Wunsch algorithm beside Smith‑Waterman
- expose Needleman-Wunsch functions in wasm API
- add option in UI to choose algorithm
- update page text and JS logic
- add tests for Needleman‑Wunsch

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68708098836083339c2da236f0666677