### PR TITLE
Improve alignment visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
             font-family: monospace;
         }
         .match { color: green; }
+        .partial { color: orange; }
         .mismatch { color: red; }
         .gap { color: gray; }
     </style>
@@ -68,6 +69,7 @@
 
                 const seq1 = result.aligned_seq1;
                 const seq2 = result.aligned_seq2;
+                const markup = result.alignment_markup;
                 let final = '';
                 let html1 = '';
                 let htmlm = '';
@@ -76,11 +78,15 @@
                 for (let i = 0; i < seq1.length; i++) {
                     const c1 = seq1[i];
                     const c2 = seq2[i];
+                    const mark = markup[i];
                     let cls = 'match';
-                    if (c1 === '-' || c2 === '-') {
+                    if (mark === ' ') {
                         cls = 'gap';
                         m = ' ';
-                    } else if (c1 !== c2) {
+                    } else if (mark === ':') {
+                        cls = 'partial';
+                        m = ':';
+                    } else if (mark === '.') {
                         cls = 'mismatch';
                         m = 'X';
                     } else {

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -62,6 +62,7 @@ pub struct AlignmentResult {
     pub aligned_seq2: String,
     pub aligned_length: usize,
     pub aligned_identity: f64,
+    pub alignment_markup: String,
 }
 
 pub fn smith_waterman_with_matrix<F>(
@@ -159,6 +160,20 @@ where
     aligned_seq1.reverse();
     aligned_seq2.reverse();
 
+    let mut markup = String::with_capacity(aligned_seq1.len());
+    for (&a, &b) in aligned_seq1.iter().zip(aligned_seq2.iter()) {
+        let ch = if a == b && a != b'-' {
+            '|'
+        } else if a == b'-' || b == b'-' {
+            ' '
+        } else if score_fn(a, b) > 0 {
+            ':'
+        } else {
+            '.'
+        };
+        markup.push(ch);
+    }
+
     AlignmentResult {
         aligned_seq1: String::from_utf8(aligned_seq1).unwrap(),
         aligned_seq2: String::from_utf8(aligned_seq2).unwrap(),
@@ -168,6 +183,7 @@ where
         } else {
             0.0
         },
+        alignment_markup: markup,
     }
 }
 
@@ -259,6 +275,20 @@ where
     aligned_seq1.reverse();
     aligned_seq2.reverse();
 
+    let mut markup = String::with_capacity(aligned_seq1.len());
+    for (&a, &b) in aligned_seq1.iter().zip(aligned_seq2.iter()) {
+        let ch = if a == b && a != b'-' {
+            '|'
+        } else if a == b'-' || b == b'-' {
+            ' '
+        } else if score_fn(a, b) > 0 {
+            ':'
+        } else {
+            '.'
+        };
+        markup.push(ch);
+    }
+
     AlignmentResult {
         aligned_seq1: String::from_utf8(aligned_seq1).unwrap(),
         aligned_seq2: String::from_utf8(aligned_seq2).unwrap(),
@@ -268,6 +298,7 @@ where
         } else {
             0.0
         },
+        alignment_markup: markup,
     }
 }
 
@@ -302,6 +333,7 @@ mod tests {
         assert_eq!(r.aligned_seq2, "GATTACA");
         assert_eq!(r.aligned_length, 7);
         assert!((r.aligned_identity - 1.0).abs() < f64::EPSILON);
+        assert_eq!(r.alignment_markup, "|||||||");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add an extra field to `AlignmentResult` with markup information
- compute partial mismatch information in both alignment algorithms
- colour partial mismatches in orange
- show alignment using the markup from Rust rather than recomputing it in JS
- test the new markup string for identical alignments

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687095c13aa48333ac73abac416d8d01