### PR TITLE
Update alignment options

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,13 @@
                     return txt === 'Show advanced parameters' ? 'Hide advanced parameters' : 'Show advanced parameters';
                 });
             });
+            $('#weight-option').on('change', function() {
+                if (this.value === 'uniform') {
+                    $('#uniform-params').addClass('show');
+                } else {
+                    $('#uniform-params').removeClass('show');
+                }
+            }).trigger('change');
         });
     </script>
 
@@ -175,12 +182,14 @@
                     </label><br>
                     <label>Scoring matrix:
                         <select id="weight-option">
-                            <option value="uniform" selected>Uniform</option>
-                            <option value="blosum62">BLOSUM62</option>
+                            <option value="uniform">Uniform</option>
+                            <option value="blosum62" selected>BLOSUM62</option>
                         </select>
                     </label><br>
-                    <label>Match score: <input type="number" id="match-score" value="2"></label><br>
-                    <label>Mismatch penalty: <input type="number" id="mismatch-penalty" value="-1"></label><br>
+                    <div id="uniform-params">
+                        <label>Match score: <input type="number" id="match-score" value="2"></label><br>
+                        <label>Mismatch penalty: <input type="number" id="mismatch-penalty" value="-1"></label><br>
+                    </div>
                     <label>Gap open penalty: <input type="number" id="gap-open" value="-1"></label><br>
                     <label>Gap extend penalty: <input type="number" id="gap-extend" value="-1"></label>
                 </div>

--- a/static/style.css
+++ b/static/style.css
@@ -66,3 +66,15 @@ nav h6 {
     text-transform: uppercase;
     font-weight: bold;
 }
+
+#uniform-params {
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    transition: max-height 0.4s ease, opacity 0.4s ease;
+}
+
+#uniform-params.show {
+    max-height: 100px;
+    opacity: 1;
+}


### PR DESCRIPTION
## Summary
- make BLOSUM62 the default scoring matrix
- hide match/mismatch options unless using uniform penalties
- smooth transitions with CSS animation

## Testing
- `./build.sh` *(fails: failed to download wasm-opt)*

------
https://chatgpt.com/codex/tasks/task_e_6870a0a5da048333b5d988d48b007fd4