### PR TITLE
Use floating point costs

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,24 +54,24 @@
                     return;
                 }
                 warningEl.style.display = 'none';
-                const gapOpen = parseInt(document.getElementById('gap-open').value, 10);
-                const gapExtend = parseInt(document.getElementById('gap-extend').value, 10);
+                const gapOpen = parseFloat(document.getElementById('gap-open').value);
+                const gapExtend = parseFloat(document.getElementById('gap-extend').value);
                 const weightOption = document.getElementById('weight-option').value;
                 let result;
                 if (algorithm === 'nw') {
                     if (weightOption === 'blosum62') {
                         result = needleman_wunsch_blosum62(parsed1.sequence, parsed2.sequence, gapOpen, gapExtend);
                     } else {
-                        const matchScore = parseInt(document.getElementById('match-score').value, 10);
-                        const mismatchPenalty = parseInt(document.getElementById('mismatch-penalty').value, 10);
+                        const matchScore = parseFloat(document.getElementById('match-score').value);
+                        const mismatchPenalty = parseFloat(document.getElementById('mismatch-penalty').value);
                         result = needleman_wunsch_custom(parsed1.sequence, parsed2.sequence, matchScore, mismatchPenalty, gapOpen, gapExtend);
                     }
                 } else {
                     if (weightOption === 'blosum62') {
                         result = smith_waterman_blosum62(parsed1.sequence, parsed2.sequence, gapOpen, gapExtend);
                     } else {
-                        const matchScore = parseInt(document.getElementById('match-score').value, 10);
-                        const mismatchPenalty = parseInt(document.getElementById('mismatch-penalty').value, 10);
+                        const matchScore = parseFloat(document.getElementById('match-score').value);
+                        const mismatchPenalty = parseFloat(document.getElementById('mismatch-penalty').value);
                         result = smith_waterman_custom(parsed1.sequence, parsed2.sequence, matchScore, mismatchPenalty, gapOpen, gapExtend);
                     }
                 }
@@ -223,7 +223,7 @@
                         <label>Mismatch penalty: <input type="number" id="mismatch-penalty" value="-1"></label><br>
                     </div>
                     <label>Gap open penalty: <input type="number" id="gap-open" value="-10"></label><br>
-                    <label>Gap extend penalty: <input type="number" id="gap-extend" value="-1"></label>
+                    <label>Gap extend penalty: <input type="number" id="gap-extend" value="-0.5"></label>
                 </div>
                 <div id="input-warning" class="alert alert-warning mt-2" style="display:none"></div>
                 <div class="btn-group" role="group">

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,17 +8,17 @@ pub use alignment::AlignmentResult;
 
 #[wasm_bindgen]
 pub fn smith_waterman(seq1: &str, seq2: &str) -> JsValue {
-    smith_waterman_custom(seq1, seq2, 2, -1, -1, -1)
+    smith_waterman_custom(seq1, seq2, 2.0, -1.0, -1.0, -0.5)
 }
 
 #[wasm_bindgen]
 pub fn smith_waterman_custom(
     seq1: &str,
     seq2: &str,
-    match_score: i32,
-    mismatch_penalty: i32,
-    gap_open: i32,
-    gap_extend: i32,
+    match_score: f64,
+    mismatch_penalty: f64,
+    gap_open: f64,
+    gap_extend: f64,
 ) -> JsValue {
     let result = alignment::smith_waterman_internal(
         seq1,
@@ -32,24 +32,24 @@ pub fn smith_waterman_custom(
 }
 
 #[wasm_bindgen]
-pub fn smith_waterman_blosum62(seq1: &str, seq2: &str, gap_open: i32, gap_extend: i32) -> JsValue {
+pub fn smith_waterman_blosum62(seq1: &str, seq2: &str, gap_open: f64, gap_extend: f64) -> JsValue {
     let result = alignment::smith_waterman_blosum62_internal(seq1, seq2, gap_open, gap_extend);
     to_value(&result).unwrap()
 }
 
 #[wasm_bindgen]
 pub fn needleman_wunsch(seq1: &str, seq2: &str) -> JsValue {
-    needleman_wunsch_custom(seq1, seq2, 2, -1, -1, -1)
+    needleman_wunsch_custom(seq1, seq2, 2.0, -1.0, -1.0, -0.5)
 }
 
 #[wasm_bindgen]
 pub fn needleman_wunsch_custom(
     seq1: &str,
     seq2: &str,
-    match_score: i32,
-    mismatch_penalty: i32,
-    gap_open: i32,
-    gap_extend: i32,
+    match_score: f64,
+    mismatch_penalty: f64,
+    gap_open: f64,
+    gap_extend: f64,
 ) -> JsValue {
     let result = alignment::needleman_wunsch_internal(
         seq1,
@@ -66,8 +66,8 @@ pub fn needleman_wunsch_custom(
 pub fn needleman_wunsch_blosum62(
     seq1: &str,
     seq2: &str,
-    gap_open: i32,
-    gap_extend: i32,
+    gap_open: f64,
+    gap_extend: f64,
 ) -> JsValue {
     let result = alignment::needleman_wunsch_blosum62_internal(seq1, seq2, gap_open, gap_extend);
     to_value(&result).unwrap()


### PR DESCRIPTION
## Summary
- allow gap costs to be floating point
- default gap extension penalty is now `-0.5`
- parse floating point values in the JS UI

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6870caac76f88333972b340ce3d63511