### PR TITLE
Add URL parameter support for alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,28 @@
             window.lastAlignment = null;
             window.updateSavedAlignments();
 
+            const params = new URLSearchParams(window.location.search);
+            const pSeq1 = params.get('seq1');
+            const pSeq2 = params.get('seq2');
+            if (pSeq1) document.getElementById('seq1').value = pSeq1;
+            if (pSeq2) document.getElementById('seq2').value = pSeq2;
+            if (params.has('gap_open')) {
+                document.getElementById('gap-open').value = params.get('gap_open');
+            }
+            if (params.has('gap_extend')) {
+                document.getElementById('gap-extend').value = params.get('gap_extend');
+            }
+            if (params.has('match_score')) {
+                document.getElementById('match-score').value = params.get('match_score');
+            }
+            if (params.has('mismatch_penalty')) {
+                document.getElementById('mismatch-penalty').value = params.get('mismatch_penalty');
+            }
+            if (params.has('weight')) {
+                document.getElementById('weight-option').value = params.get('weight');
+                $('#weight-option').trigger('change');
+            }
+
             window.alignSequences = (algorithm) => {
                 const parsed1 = parseFasta(document.getElementById('seq1').value, 'sequence1');
                 const parsed2 = parseFasta(document.getElementById('seq2').value, 'sequence2');
@@ -227,6 +249,7 @@
                     }
                 }
                 displayResult(result, algorithm);
+
                 window.lastAlignment = {
                     name1: parsed1.name,
                     name2: parsed2.name,
@@ -236,7 +259,13 @@
                     result,
                     timestamp: Date.now()
                 };
-                };
+            };
+
+            const modeParam = params.get('mode');
+            if (pSeq1 && pSeq2) {
+                const mode = (modeParam === 'nw' || modeParam === 'global') ? 'nw' : 'sw';
+                window.alignSequences(mode);
+            }
 
         }
 


### PR DESCRIPTION
## Summary
- load sequence and scoring parameters from URL query string
- allow automatic alignment when `seq1` and `seq2` parameters are present

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6871ce4b9d3c8333a8179f4767cddad8