### PR TITLE
Add shareable link for saved alignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Rust implementation of some simple bioinformatics tools designed to run in the b
 
 Live version: [https://web-bio-tools.big-data-biology.org/](https://web-bio-tools.big-data-biology.org/)
 
+Saved alignments can generate shareable URLs that reproduce the alignment when opened.
+
 
 ## Local development
 

--- a/index.html
+++ b/index.html
@@ -121,6 +121,13 @@
                     const time = document.createElement('small');
                     time.className = 'text-muted ml-2';
                     time.textContent = new Date(item.timestamp).toLocaleString();
+                    const share = document.createElement('button');
+                    share.className = 'btn btn-link btn-sm float-right';
+                    share.innerHTML = '<i class="fa fa-share"></i>';
+                    share.addEventListener('click', (e) => {
+                        e.preventDefault();
+                        window.shareSavedAlignment(idx);
+                    });
                     const del = document.createElement('button');
                     del.className = 'btn btn-link btn-sm text-danger float-right';
                     del.innerHTML = '&times;';
@@ -130,6 +137,7 @@
                     });
                     li.appendChild(a);
                     li.appendChild(time);
+                    li.appendChild(share);
                     li.appendChild(del);
                     list.appendChild(li);
                 });
@@ -190,6 +198,33 @@
                 document.getElementById('seq1').value = `>${item.name1}\n${item.seq1}`;
                 document.getElementById('seq2').value = `>${item.name2}\n${item.seq2}`;
                 displayResult(item.result, item.algorithm);
+            }
+
+            window.shareSavedAlignment = function(idx) {
+                const saved = JSON.parse(localStorage.getItem('savedAlignments') || '[]');
+                const item = saved[idx];
+                if (!item) return;
+                const url = new URL(window.location.href.split('?')[0]);
+                url.searchParams.set('seq1', `>${item.name1}\n${item.seq1}`);
+                url.searchParams.set('seq2', `>${item.name2}\n${item.seq2}`);
+                url.searchParams.set('gap_open', item.gapOpen);
+                url.searchParams.set('gap_extend', item.gapExtend);
+                url.searchParams.set('weight', item.weightOption);
+                if (item.weightOption === 'uniform') {
+                    url.searchParams.set('match_score', item.matchScore);
+                    url.searchParams.set('mismatch_penalty', item.mismatchPenalty);
+                }
+                url.searchParams.set('mode', item.algorithm);
+                const shareUrl = url.toString();
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(shareUrl).then(() => {
+                        alert('Share URL copied to clipboard.');
+                    }, () => {
+                        window.prompt('Share this URL', shareUrl);
+                    });
+                } else {
+                    window.prompt('Share this URL', shareUrl);
+                }
             }
 
             window.downloadAlignment = function() {


### PR DESCRIPTION
## Summary
- add share button for each saved alignment
- implement `shareSavedAlignment` to create a URL with the same parameters and copy it to the clipboard
- document new shareable URL feature in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6871d2bc1c4483339876b723ecca421c