### PR TITLE
Improve date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Rust implementation of some simple bioinformatics tools designed to run in the b
 
 Live version: [https://web-bio-tools.big-data-biology.org/](https://web-bio-tools.big-data-biology.org/)
 
+Saved alignments can generate shareable URLs that reproduce the alignment when opened.
+
 
 ## Local development
 

--- a/index.html
+++ b/index.html
@@ -133,6 +133,13 @@
                     const time = document.createElement('small');
                     time.className = 'text-muted ml-2';
                     time.textContent = formatDate(item.timestamp);
+                    const share = document.createElement('button');
+                    share.className = 'btn btn-link btn-sm float-right';
+                    share.innerHTML = '<i class="fa fa-share"></i>';
+                    share.addEventListener('click', (e) => {
+                        e.preventDefault();
+                        window.shareSavedAlignment(idx);
+                    });
                     const del = document.createElement('button');
                     del.className = 'btn btn-link btn-sm text-danger float-right';
                     del.innerHTML = '&times;';
@@ -142,6 +149,7 @@
                     });
                     li.appendChild(a);
                     li.appendChild(time);
+                    li.appendChild(share);
                     li.appendChild(del);
                     list.appendChild(li);
                 });
@@ -202,6 +210,33 @@
                 document.getElementById('seq1').value = `>${item.name1}\n${item.seq1}`;
                 document.getElementById('seq2').value = `>${item.name2}\n${item.seq2}`;
                 displayResult(item.result, item.algorithm);
+            }
+
+            window.shareSavedAlignment = function(idx) {
+                const saved = JSON.parse(localStorage.getItem('savedAlignments') || '[]');
+                const item = saved[idx];
+                if (!item) return;
+                const url = new URL(window.location.href.split('?')[0]);
+                url.searchParams.set('seq1', `>${item.name1}\n${item.seq1}`);
+                url.searchParams.set('seq2', `>${item.name2}\n${item.seq2}`);
+                url.searchParams.set('gap_open', item.gapOpen);
+                url.searchParams.set('gap_extend', item.gapExtend);
+                url.searchParams.set('weight', item.weightOption);
+                if (item.weightOption === 'uniform') {
+                    url.searchParams.set('match_score', item.matchScore);
+                    url.searchParams.set('mismatch_penalty', item.mismatchPenalty);
+                }
+                url.searchParams.set('mode', item.algorithm);
+                const shareUrl = url.toString();
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(shareUrl).then(() => {
+                        alert('Share URL copied to clipboard.');
+                    }, () => {
+                        window.prompt('Share this URL', shareUrl);
+                    });
+                } else {
+                    window.prompt('Share this URL', shareUrl);
+                }
             }
 
             window.downloadAlignment = function() {

--- a/index.html
+++ b/index.html
@@ -101,6 +101,18 @@
                 document.getElementById('alignment-mode').textContent = algorithm === 'nw' ? 'global' : 'local';
             }
 
+            function formatDate(ts) {
+                const d = new Date(ts);
+                const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+                const day = d.getDate().toString().padStart(2, '0');
+                const month = months[d.getMonth()];
+                const year = d.getFullYear();
+                const hours = d.getHours().toString().padStart(2, '0');
+                const minutes = d.getMinutes().toString().padStart(2, '0');
+                const seconds = d.getSeconds().toString().padStart(2, '0');
+                return `${day} ${month} ${year} ${hours}:${minutes}:${seconds}`;
+            }
+
             let rightbarShown = false;
             window.updateSavedAlignments = function() {
                 const saved = JSON.parse(localStorage.getItem('savedAlignments') || '[]');
@@ -120,7 +132,7 @@
                     });
                     const time = document.createElement('small');
                     time.className = 'text-muted ml-2';
-                    time.textContent = new Date(item.timestamp).toLocaleString();
+                    time.textContent = formatDate(item.timestamp);
                     const del = document.createElement('button');
                     del.className = 'btn btn-link btn-sm text-danger float-right';
                     del.innerHTML = '&times;';
@@ -222,7 +234,7 @@
                 }
 
                 let content = 'Sequence Alignment\n';
-                content += 'Time: ' + new Date(a.timestamp).toLocaleString() + '\n';
+                content += 'Time: ' + formatDate(a.timestamp) + '\n';
                 content += 'Algorithm: ' + (a.algorithm === 'nw' ? 'global (Needleman-Wunsch)' : 'local (Smith-Waterman)') + '\n';
                 content += 'Scoring matrix: ' + a.weightOption + '\n';
                 if (a.weightOption === 'uniform') {


### PR DESCRIPTION
## Summary
- use a helper function to format dates as day-month-year with month names
- show saved alignment and downloaded alignment timestamps with the new format

## Testing
- `cargo test --verbose`

------
https://chatgpt.com/codex/tasks/task_e_6871d341f49c8333893a0a762f722ce9