### PR TITLE
Fix tests to use PairwiseAligner API

### DIFF
--- a/tests/test_py_biopython.py
+++ b/tests/test_py_biopython.py
@@ -1,14 +1,17 @@
 import web_bio_tools
-from Bio import pairwise2
-from Bio.Align import substitution_matrices
+from Bio.Align import PairwiseAligner, substitution_matrices
 
 
 def test_sw_blosum62_score():
     seq1 = "HEAGAWGHEE"
     seq2 = "PAWHEAE"
     result = web_bio_tools.smith_waterman_blosum62(seq1, seq2, -10.0, -0.5)
-    matrix = substitution_matrices.load("BLOSUM62")
-    ref = pairwise2.align.localds(seq1, seq2, matrix, -10.0, -0.5)[0]
+    aligner = PairwiseAligner()
+    aligner.mode = "local"
+    aligner.substitution_matrix = substitution_matrices.load("BLOSUM62")
+    aligner.open_gap_score = -10.0
+    aligner.extend_gap_score = -0.5
+    ref = aligner.align(seq1, seq2)[0]
     assert abs(result.score - ref.score) < 1e-6
 
 
@@ -16,7 +19,13 @@ def test_nw_globalms():
     seq1 = "GATTACA"
     seq2 = "GATTACA"
     result = web_bio_tools.needleman_wunsch(seq1, seq2)
-    ref = pairwise2.align.globalms(seq1, seq2, 2, -1, -1, -0.5)[0]
-    assert result.aligned_seq1 == ref.seqA
-    assert result.aligned_seq2 == ref.seqB
+    aligner = PairwiseAligner()
+    aligner.mode = "global"
+    aligner.match_score = 2
+    aligner.mismatch_score = -1
+    aligner.open_gap_score = -1
+    aligner.extend_gap_score = -0.5
+    ref = aligner.align(seq1, seq2)[0]
+    assert result.aligned_seq1 == ref[0]
+    assert result.aligned_seq2 == ref[1]
     assert abs(result.score - ref.score) < 1e-6


### PR DESCRIPTION
## Summary
- update Python tests to use `Bio.Align.PairwiseAligner`

## Testing
- `cargo test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873aaa441388333a0eb256d65f6d7b3