### PR TITLE
Add warning for mismatched gap penalties

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,6 +345,10 @@
                 }
                 const gapOpen = parseFloat(document.getElementById('gap-open').value);
                 const gapExtend = parseFloat(document.getElementById('gap-extend').value);
+                if (gapExtend < gapOpen) {
+                    warningEl.textContent = 'Gap extend penalty should be less severe than the gap open penalty.';
+                    warningEl.style.display = 'block';
+                }
                 const weightOption = document.getElementById('weight-option').value;
                 let result;
                 if (algorithm === 'nw') {


### PR DESCRIPTION
## Summary
- notify users when the gap extension penalty is stronger than the gap open penalty

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687442c43f188333917c0e783430c9f1