### PR TITLE
Fix wasm build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,14 @@ license = "MIT"
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
-pyo3 = { version = "0.20", features = ["extension-module"] }
+pyo3 = { version = "0.20", optional = true, features = ["extension-module"] }
+
+[features]
+default = []
+python = ["pyo3"]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
 
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ wasm-pack`) and then run:
 wasm-pack build --target web
 ```
 
+The Python bindings are optional. To build them with
+[`maturin`](https://github.com/PyO3/maturin), enable the `python`
+feature:
+
+```bash
+maturin build --features python
+```
+
 You can test the tools in your browser by running a local server. For example, using Python:
 
 ```bash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
 
 mod alignment;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "python", not(target_arch = "wasm32")))]
 mod python;
 
 pub use alignment::AlignmentResult;


### PR DESCRIPTION
## Summary
- make `pyo3` optional and disable by default so wasm build does not try to compile Python bindings
- guard `python` module behind a feature flag
- add README section explaining how to build Python bindings with `maturin`
- disable `wasm-opt` download in CI to avoid network fetches

## Testing
- `wasm-pack build --target web`
- `maturin build --release --features python`
- `pip install target/wheels/web_bio_tools-0.1.0-cp311-cp311-manylinux_2_34_x86_64.whl`
- `pytest -q tests/test_py_biopython.py`

------
https://chatgpt.com/codex/tasks/task_e_6874449ea1048333b30f706d34740879